### PR TITLE
Catch NameResolutionError when fetching models while offline

### DIFF
--- a/llm_gpt4all.py
+++ b/llm_gpt4all.py
@@ -2,6 +2,7 @@ from gpt4all import GPT4All as _GPT4All
 from pathlib import Path
 from typing import Optional
 import httpx
+import urllib3
 import json
 import llm
 import os
@@ -166,7 +167,7 @@ def fetch_cached_json(url, path, cache_timeout):
             json.dump(response.json(), file)
 
         return response.json()
-    except httpx.HTTPError:
+    except (httpx.HTTPError, urllib3.exceptions.NameResolutionError):
         # If there's an existing file, load it
         if path.is_file():
             with open(path, "r") as file:


### PR DESCRIPTION
Thanks for putting this together! Been experimenting with this in offline-first context.

Currently when I try to run a gpt4 model while offline I get the following stack trace on Linux:

```
➜  ~ llm -m orca-mini-3b "Write a python map from NATO phonetic alphabet to its letter"
Error: HTTPSConnectionPool(host='gpt4all.io', port=443): Max retries exceeded with url: /models/models.json (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7f6aa1f25f10>: Failed to resolve 'gpt4all.io' ([Errno -3] Temporary failure in name resolution)"))
```

This PR attempts to catch that exception and continue with the "load from file" logic.

To be clear, this is after having successfully run the command while online and having the model and the models.json file cached on my filesystem.