### PR TITLE
feat: Add cli options for generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,41 @@ On subsequent uses the model output will be displayed immediately.
 
 Note that the models will be downloaded to `~/.cache/gpt4all`.
 
+### Model options
+
+Run `llm models --options` for a list of available model options, which should include:
+
+```
+gpt4all: mistral-7b-instruct-v0 - Mistral Instruct, 3.83GB download, needs 8GB RAM (installed)
+  max_tokens: int
+    The maximum number of tokens to generate.
+  temp: float
+    The model temperature. Larger values increase creativity but decrease
+    factuality.
+  top_k: int
+    Randomly sample from the top_k most likely tokens at each generation
+    step. Set this to 1 for greedy decoding.
+  top_p: float
+    Randomly sample at each generation step from the top most likely
+    tokens whose probabilities add up to top_p.
+  repeat_penalty: float
+    Penalize the model for repetition. Higher values result in less
+    repetition.
+  repeat_last_n: int
+    How far in the models generation history to apply the repeat penalty.
+  n_batch: int
+    Number of prompt tokens processed in parallel. Larger values decrease
+    latency but increase resource requirements.
+```
+Use them like this:
+
+```bash
+llm -m mistral-7b-instruct-v0 -o max_tokens 2 'hi'
+```
+```
+Hello!
+```
+
 ### Chatting
 
 To chat with a model, avoiding the need to load it into memory for every message, use `llm chat`:
@@ -81,15 +116,16 @@ To remove a downloaded model, delete the `.gguf` file from `~/.cache/gpt4all`.
 ## Development
 
 To set up this plugin locally, first checkout the code. Then create a new virtual environment:
-
-    cd llm-gpt4all
-    python3 -m venv venv
-    source venv/bin/activate
-
+```bash
+cd llm-gpt4all
+python3 -m venv venv
+source venv/bin/activate
+```
 Now install the dependencies and test dependencies:
-
-    pip install -e '.[test]'
-
+```bash
+pip install -e '.[test]'
+```
 To run the tests:
-
-    pytest
+```bash
+pytest
+```

--- a/llm_gpt4all.py
+++ b/llm_gpt4all.py
@@ -11,6 +11,15 @@ import time
 from typing import List, Optional, Tuple
 
 
+try:
+    from pydantic import Field, field_validator  # type: ignore
+except ImportError:
+    from pydantic.class_validators import (
+        validator as field_validator,
+    )  # type: ignore [no-redef]
+    from pydantic.fields import Field
+
+
 class GPT4All(_GPT4All):
     # Switch verbose default to False
     @staticmethod
@@ -49,6 +58,29 @@ def register_models(register):
 
 class Gpt4AllModel(llm.Model):
     can_stream = True
+
+    class Options(llm.Options):
+        max_tokens: int = Field(
+            description="The maximum number of tokens to generate.", default=200
+        )
+        temp: float = Field(
+            description="The model temperature. Larger values increase creativity but decrease factuality.", default=0.7
+        )
+        top_k: int = Field(
+            description="Randomly sample from the top_k most likely tokens at each generation step. Set this to 1 for greedy decoding.", default=40
+        )
+        top_p: float = Field(
+            description="Randomly sample at each generation step from the top most likely tokens whose probabilities add up to top_p.", default=0.4
+        )
+        repeat_penalty: float = Field(
+            description="Penalize the model for repetition. Higher values result in less repetition.", default=1.18
+        )
+        repeat_last_n: int = Field(
+            description="How far in the models generation history to apply the repeat penalty.", default=64
+        )
+        n_batch: int = Field(
+            description="Number of prompt tokens processed in parallel. Larger values decrease latency but increase resource requirements.", default=8
+        )
 
     def __init__(self, details):
         self._details = details
@@ -109,7 +141,17 @@ class Gpt4AllModel(llm.Model):
                 text_prompt = f"{system}\n{text_prompt}"
             response.response_json = {"full_prompt": text_prompt}
             gpt_model = GPT4All(self.filename())
-            output = gpt_model.generate(text_prompt, max_tokens=400, streaming=True)
+            output = gpt_model.generate(
+                text_prompt,
+                streaming=True,
+                max_tokens = prompt.options.max_tokens or 400,
+                temp = prompt.options.temp,
+                top_k = prompt.options.top_k,
+                top_p = prompt.options.top_p,
+                repeat_penalty = prompt.options.repeat_penalty,
+                repeat_last_n = prompt.options.repeat_last_n,
+                n_batch = prompt.options.n_batch,
+            )
             yield from output
 
     def filename(self):


### PR DESCRIPTION
Refs:
- #3

Per our discussion on the fediverse.

I took the parameter descriptions from the [gpt4all python docs](https://docs.gpt4all.io/gpt4all_python.html#gpt4all.gpt4all.GPT4All.generate) and copied the structure from [the llm-llama-cpp plugin](https://github.com/simonw/llm-llama-cpp/blob/main/llm_llama_cpp.py#L181)

Does this work? Any other changes that I should make?