### PR TITLE
fix: allow local models to work without internet connection

### DIFF
--- a/llm_gpt4all.py
+++ b/llm_gpt4all.py
@@ -11,6 +11,10 @@ import time
 from typing import List, Optional, Tuple
 
 
+# Hardcode default model_path since the library doesn't expose it programmatically
+# https://docs.gpt4all.io/gpt4all_python.html#api-documentation
+GPT4ALL_MODEL_DIRECTORY = Path.home() / ".cache" / "gpt4all"
+
 class GPT4All(_GPT4All):
     # Switch verbose default to False
     @staticmethod
@@ -108,7 +112,13 @@ class Gpt4AllModel(llm.Model):
             if system:
                 text_prompt = f"{system}\n{text_prompt}"
             response.response_json = {"full_prompt": text_prompt}
-            gpt_model = GPT4All(self.filename())
+
+            # We assume file existing is enough to enable download, does not check if file is complete
+            model_name = self.filename()
+            model_exists_locally = Path(GPT4ALL_MODEL_DIRECTORY / model_name).exists()
+            allow_download = not model_exists_locally
+            gpt_model = GPT4All(model_name, allow_download=allow_download)
+
             output = gpt_model.generate(text_prompt, max_tokens=400, streaming=True)
             yield from output
 


### PR DESCRIPTION
## Motivation

Currently, the library tries to download the model even if it already exists locally, which prevents offline use.

Fixes https://github.com/simonw/llm-gpt4all/issues/10 , applying a code hint and investigation from @rotterb

## Changes

Avoid trying to download model when that model's file already exists

## Testing

I tried running the plugin with wifi disabled using a model that I had already downloaded.

```bash
llm uninstall llm-gpt4all
# changed into this project's directory
pip install -e '.[test]'
# turn wifi off
llm -m mistral-7b-instruct-v0 "hello world"
# received proper output
```
