### PR TITLE
Fixes #32 - create GPT4AllModel Option for device

### DIFF
--- a/llm_gpt4all.py
+++ b/llm_gpt4all.py
@@ -99,6 +99,10 @@ class Gpt4AllModel(llm.Model):
             description="Number of prompt tokens processed in parallel. Larger values decrease latency but increase resource requirements.",
             default=8,
         )
+        device: str = Field(
+            description="Device to use per the GPT4All constructor documentation, i.e 'cpu', 'gpu', 'amd', 'intel'",
+            default = 'cpu'
+        )
 
     def __init__(self, details):
         self._details = details
@@ -163,7 +167,7 @@ class Gpt4AllModel(llm.Model):
             model_name = self.filename()
             model_exists_locally = Path(GPT4ALL_MODEL_DIRECTORY / model_name).exists()
             allow_download = not model_exists_locally
-            gpt_model = GPT4All(model_name, allow_download=allow_download)
+            gpt_model = GPT4All(model_name, allow_download=allow_download,device=prompt.options.device)
             output = gpt_model.generate(
                 text_prompt,
                 streaming=True,

--- a/llm_gpt4all.py
+++ b/llm_gpt4all.py
@@ -101,7 +101,11 @@ class Gpt4AllModel(llm.Model):
         )
         device: str = Field(
             description="Device to use per the GPT4All constructor documentation, i.e 'cpu', 'gpu', 'amd', 'intel'",
-            default = 'cpu'
+            default="cpu",
+        )
+        window: int = Field(
+            description="Context window size",
+            default=2048,
         )
 
     def __init__(self, details):
@@ -167,7 +171,12 @@ class Gpt4AllModel(llm.Model):
             model_name = self.filename()
             model_exists_locally = Path(GPT4ALL_MODEL_DIRECTORY / model_name).exists()
             allow_download = not model_exists_locally
-            gpt_model = GPT4All(model_name, allow_download=allow_download,device=prompt.options.device)
+            gpt_model = GPT4All(
+                model_name,
+                allow_download=allow_download,
+                device=prompt.options.device,
+                n_ctx=prompt.options.window,
+            )
             output = gpt_model.generate(
                 text_prompt,
                 streaming=True,


### PR DESCRIPTION
Fixes #32 

I hope I'm not getting ahead of myself, but put together this modest commit to allow for passing in the device to GPT4All. It adds an Option for device, and then passes that in when GPT4All(...) is instantiated.

I went back and forth on the default value for this, if it should be `cpu` or `None`, and am submitting this with `cpu`. Currently, GPT4All uses `cpu` as its default, and I imagine this is unlikely to change. I considered `None`, which would then make GPT4All decide how to handle a `None` - which currently is exactly the same as if it is `cpu`, and so just using `cpu` seemed to make more sense.

I tested this for myself, but did not create any actual tests for the library for this. It isn't really clear to me how the testing fake responses are working in there...