### PR TITLE
Fix inaccessible duplicated model IDs

### DIFF
--- a/llm_gpt4all.py
+++ b/llm_gpt4all.py
@@ -102,7 +102,7 @@ class Gpt4AllModel(llm.Model):
 
     def __init__(self, details):
         self._details = details
-        self.model_id = details["filename"].split(".")[0]
+        self.model_id = details["filename"].rsplit(".", maxsplit=1)[0]
 
     def prompt_template(self):
         return (


### PR DESCRIPTION
Fixes #43 (also mentioned in #29).

Splits on the last period to remove the file extension, instead of the first period.

Previously
Llama-3.2-3B-Instruct-Q4_0.gguf => Llama-3
Llama-3.2-1B-Instruct-Q4_0.gguf => Llama-3

Now
Llama-3.2-3B-Instruct-Q4_0.gguf => Llama-3.2-3B-Instruct-Q4_0
Llama-3.2-1B-Instruct-Q4_0.gguf => Llama-3.2-1B-Instruct-Q4_0